### PR TITLE
Overlap in about section

### DIFF
--- a/client/src/styles/app.scss
+++ b/client/src/styles/app.scss
@@ -451,8 +451,6 @@ nav .menu-btn,
   .a-b-img img {
     object-fit: contain;
   }
-}
-@media (max-width: 970px) {
   .main {
     background-image: none !important;
   }
@@ -483,6 +481,8 @@ nav .menu-btn,
   .about-text p {
     width: 100%;
   }
+}
+@media (max-width: 970px) {
   #features {
     margin-bottom: 100px;
   }


### PR DESCRIPTION
<img width="866" alt="Screen Shot 2021-08-25 at 7 03 28 PM" src="https://user-images.githubusercontent.com/52601237/130875567-d60b16c9-3816-401d-bfd5-5aa6bfedf76a.png">
overlap fixed 
closes #192 